### PR TITLE
#119 Auf Monitor Seite geleitet werden, wenn konfiguriert

### DIFF
--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,0 +1,26 @@
+import { endpoints, getBackendUrl } from '$lib/backend-util';
+import { HTTP_METHOD } from '$lib/fetching-util';
+import { redirect, type Load } from '@sveltejs/kit';
+
+/**
+ * Redirects to the monitor page if backend is configured. If backend not available,
+ * or not configured, the page will load normally.
+ */
+export const load: Load = async ({ fetch }) => {
+    // Do not use retry policy to prevent long page loading
+    try {
+        const res = await fetch(
+            // Use power state since this returns quickly
+            getBackendUrl() + endpoints.get.power_state,
+            { method: HTTP_METHOD.GET.toString() },
+        );
+
+        if (res.status !== 409) {
+            throw redirect(307, '/monitor');
+        }
+    } catch (e) {
+        console.warn(e);
+    }
+
+    return {};
+};


### PR DESCRIPTION
Die Svelte load function https://svelte.dev/docs/kit/load wird jetzt verwendet, um eine Anfrage an das Backend zu schicken. 

Wenn nicht Status code 409 (not configured) zurückkommt, wird auf die /monitor Seite geleitet.