### PR TITLE
Fix für #119 Auf Monitor Seite geleitet werden, wenn konfiguriert

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -6,7 +6,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         %sveltekit.head%
     </head>
-    <body data-sveltekit-preload-data="hover">
+    <!-- Hard code background so it is available during page load -->
+    <body data-sveltekit-preload-data="hover" style="background: oklch(26.9% 0 0deg)">
         <div style="display: contents">%sveltekit.body%</div>
     </body>
 </html>

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -7,20 +7,19 @@ import { redirect, type Load } from '@sveltejs/kit';
  * or not configured, the page will load normally.
  */
 export const load: Load = async ({ fetch }) => {
-    // Do not use retry policy to prevent long page loading
+    let response;
     try {
-        const res = await fetch(
+        // Do not use retry policy to prevent long page loading
+        response = await fetch(
             // Use power state since this returns quickly
             getBackendUrl() + endpoints.get.power_state,
             { method: HTTP_METHOD.GET.toString() },
         );
-
-        if (res.status !== 409) {
-            throw redirect(307, '/monitor');
-        }
     } catch (e) {
         console.warn(e);
     }
 
-    return {};
+    if (response?.status !== 409) {
+        throw redirect(307, '/monitor');
+    }
 };


### PR DESCRIPTION
Durch einen refactor wurde der redirect gecatcht und konnte nicht richtig ausgeführt werden.

Dieser wird jetzt wieder richtig Server seitig ausgeführt und der Hintergrund ist grau auch während die Seite lädt.
