### PR TITLE
Sunrise API Fehler behandeln

### DIFF
--- a/src/routes/configure/+page.svelte
+++ b/src/routes/configure/+page.svelte
@@ -167,10 +167,9 @@
                     class="bg-tertiary-500 flex items-center justify-center rounded-md p-3"
                     bind:this={warningRef}
                 >
-                    <p class=" text-center text-sm">
-                        <ShieldAlert class="mb-0.5 inline h-4 w-4" /> Für die ausgewählten Koordinaten
-                        gibt es keine gültigen Sonnenstunden-Daten. Bitte wähle keinen Standort in der
-                        Nähe der Pole.
+                    <p class=" text-center text-sm font-semibold">
+                        <ShieldAlert class="mb-0.5 inline h-4 w-4" /> Hast du einen Pinguin 🐧? Bitte wähle keinen Standort in der
+                        Nähe der Pole!
                     </p>
                 </div>
             {:else}


### PR DESCRIPTION
Wenn die Sunrise API komische Daten zurückgibt wird folgende Fehlermeldung angezeigt und zu dieser gescrollt.

![grafik](https://github.com/user-attachments/assets/a1f4d7ac-e2de-49cb-8e5e-687ee5d7151b)

Das ist relevant, weil es realistsich in der Demo vorkommen könnte.